### PR TITLE
Update FlaGs_linux.py

### DIFF
--- a/FlaGs_linux.py
+++ b/FlaGs_linux.py
@@ -6,7 +6,7 @@ from Bio import SeqIO
 from Bio import Entrez
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
-from Bio.Alphabet import generic_protein, IUPAC
+# from Bio.Alphabet import generic_protein, IUPAC
 import math, re
 import argparse
 import ftplib


### PR DESCRIPTION
As per Biopython documentation: "Bio.Alphabet has been removed from Biopython. In many cases, the alphabet can simply be ignored and removed from scripts."
Also, the install script needs to be updated so as not to install 'ete_toolchain' in the conda environment (it's a dead project and the new 'ete3' package seems to be working fine from my end, but this may need to be verified).